### PR TITLE
feat: reusable workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check-fmt:
-    uses: RustLangES/.github/workflows/templates/format.yml@main
+    uses: RustLangES/.github/.github/workflows/templates/format.yml@main
     with:
       runs-on: ubuntu-latest
       name: Checks

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check-fmt:
-    uses: RustLangES/.github/.github/workflows/templates/format.yml@main
+    uses: RustLangES/.github/.github/workflows/format.yml@main
     with:
       runs-on: ubuntu-latest
       name: Checks

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,14 +12,13 @@ on:
 
 jobs:
   check-fmt:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: checks
-        run: |
-          cargo fmt --all --check
+    uses: RustLangES/.github/workflows/templates/format.yml@main
+    with:
+      runs-on: ubuntu-latest
+      name: Checks
+      command: "--all --check"
+      fmt-version: stable
+      checkout-version: v4
 
   check-clippy:
     needs: [check-fmt]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,8 +17,6 @@ jobs:
       runs-on: ubuntu-latest
       name: Checks
       command: "--all --check"
-      fmt-version: stable
-      checkout-version: v4
 
   check-clippy:
     needs: [check-fmt]


### PR DESCRIPTION
First idea to implement re-usable workflows, the one being consumed, is from here https://github.com/RustLangES/.github/blob/main/.github/workflows/format.yml

I'll suggest we just create a repository called workflows so instead of doing `RustLangES/.github/.github/workflows/format.yml@main` we can do something like `RustLangES/actions/.github/workflows/<action>.yml@version`